### PR TITLE
Bump intro_python to v0.5.1 (gapminder data)

### DIFF
--- a/vars/ondemand-config.yml.example
+++ b/vars/ondemand-config.yml.example
@@ -108,9 +108,9 @@ ood_apps:
     pre_pull: false
 
   intro_python:
-    k8s_container: ghcr.io/nesi/training-environment-jupyter-python-app:v0.4.1
+    k8s_container: ghcr.io/nesi/training-environment-jupyter-python-app:v0.5.1
     repo: https://github.com/nesi/training-environment-jupyter-python-app.git
-    version: 'v0.4.1'
+    version: 'v0.5.1'
     enabled: false
     pre_pull: false
 


### PR DESCRIPTION
Points the `intro_python` app at the release that carries the gapminder data (nesi/intro-python#5).

```diff
   intro_python:
-    k8s_container: ghcr.io/nesi/training-environment-jupyter-python-app:v0.4.1
+    k8s_container: ghcr.io/nesi/training-environment-jupyter-python-app:v0.5.1
     repo: https://github.com/nesi/training-environment-jupyter-python-app.git
-    version: 'v0.4.1'
+    version: 'v0.5.1'
```

Both fields move together, as they must.

## What's in v0.5.1

- `nesi/intro-python` [v0.5.0](https://github.com/nesi/intro-python/releases/tag/v0.5.0) adds gapminder in both shapes: `data/gapminder.csv` (tidy long, 1704 rows) and the Software Carpentry wide files `data/gapminder_all.csv` + `data/gapminder_gdp_{africa,americas,asia,europe,oceania}.csv`, plus `data/README.md` with columns and provenance.
- The app repo now pins its content by release tag (`ARG PYTHON_VERSION`) instead of a commit SHA, matching the other app repos.
- `submit.yml.erb` in the app repo was two releases behind (`v0.4.0`); v0.5.1 fixes that.

## Ordering — please read

**Do not deploy `v0.5.0`.** That tag was pushed before the `submit.yml.erb` bump landed, so at `v0.5.0` the app still requests the `v0.4.0` image and a deploy would silently launch the old container without the gapminder data. v0.5.1 is the good release.

This PR is ready but should merge **after** [app repo PR #7](https://github.com/nesi/training-environment-jupyter-python-app/pull/7) merges, the `v0.5.1` tag is pushed, and CI has published `ghcr.io/nesi/training-environment-jupyter-python-app:v0.5.1`.

Two things left alone deliberately: `enabled: false` on this app is unchanged, and no deploy has been triggered — `deploy.yml` is `workflow_dispatch` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
